### PR TITLE
Update createQuery.ts

### DIFF
--- a/src/hooks/createQuery.ts
+++ b/src/hooks/createQuery.ts
@@ -218,12 +218,7 @@ export function createQuery<Data = any, Variables = object>(
   }
 
   const dataAccessor = () => {
-    const nextState = state.nextState
-    const keys = Object.keys(nextState.data || [])
-    if (keys.length > 0) {
-      return (nextState.data as any)[keys[0]] as Data
-    }
-    return undefined
+    return state.nextState?.data as Data
   }
 
   return [dataAccessor, () => state.nextState, executeQuery]


### PR DESCRIPTION
Current the types are incorrect when we default to the first key within the `response.data` object.

Another reason we dont want to default to the first key is it's possible for a query to have multiple top level queries that wouldnt be accessible with this default.

Ex:

```
query {
  user1: user(id: 1) { id }
  user2: user(id: 2) { id }
}
```